### PR TITLE
Adjust global Grid when a map is placed

### DIFF
--- a/Objects/Scenario 1.c3f65a.ttslua
+++ b/Objects/Scenario 1.c3f65a.ttslua
@@ -36,3 +36,5 @@ buttonData = {
     [1] = { position = {-0.67, 0.1, -0.91}, label = 'Click the scenario number\nfor automated setup', labelPosition = {-0.67, 0, -1.1},
         message = 'When the scenario is complete, unlock (\'L\'), and delete the scenario sheet.', nextButtons = { }, action = "initializeScenario", hint = 'Setup Scenario'}
 }
+
+gridData = { scale =  2.62, x = -1.7, y = 0.0 }

--- a/Objects/Scenario 10.a58767.ttslua
+++ b/Objects/Scenario 10.a58767.ttslua
@@ -97,3 +97,5 @@ buttonData = {
    [3] = { position = {0.68, 0.1, 0.28}, nextButtons = { 4 }, action = 'setupRoom', hint = 'Open door', overrideButtonHeight = hexHeight},
    [4] = { position = {1.76, 0.1, -0.68}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards'}
 }
+
+gridData = { scale =  2.65, x = -0.2, y = -0.9 }

--- a/Objects/Scenario 11.65a9bd.ttslua
+++ b/Objects/Scenario 11.65a9bd.ttslua
@@ -112,3 +112,5 @@ buttonData = {
    [3] = { position = {0.74, 0.1, 0.16}, label = '', message = '', nextButtons = { 4 }, action = "setupRoom", hint = 'Open door'},
    [4] = { position = {1.59 , 0.1, -0.88}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
+
+gridData = { scale =  2.67, x = -0.2, y = 0.7 }

--- a/Objects/Scenario 12.d32d45.ttslua
+++ b/Objects/Scenario 12.d32d45.ttslua
@@ -110,6 +110,8 @@ buttonData = {
     [9] = { position = {-0.79, -0.1, -0.97}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.74, x = -1.0, y = 0.9 }
+
 function destroyPillarA()
     cleanupButton(2)
     setupRoom(2)

--- a/Objects/Scenario 13.097811.ttslua
+++ b/Objects/Scenario 13.097811.ttslua
@@ -108,3 +108,5 @@ buttonData = {
    [3] = { position = {0.64, 0.1, -0.16}, label = '', message = '', nextButtons = { 4 }, action = "setupRoom", hint = 'Open door'},
    [4] = { position = {0.34, 0.1, 0.74}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
+
+gridData = { scale =  2.71, x = -0.9, y = 1.0 }

--- a/Objects/Scenario 14.18a953.ttslua
+++ b/Objects/Scenario 14.18a953.ttslua
@@ -85,9 +85,11 @@ overlayPositionsByRoom = {
     }
 
  }
- 
+
  buttonData = {
     [1] = { position = {-1.094, 0.1, -0.93}, label = '', message = '', nextButtons = { 2 }, action = "initializeScenario", hint = 'Setup Scenario'},
     [2] = { position = {-0.38, 0.1, 0.28}, label = '', message = '', nextButtons = { 3 }, action = "setupRoom", hint = 'Open door'},
     [3] = { position = {0.36, 0.1, 0.85}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
  }
+
+ gridData = { scale =  2.58, x = -1.0, y = 1.1 }

--- a/Objects/Scenario 15.4f078c.ttslua
+++ b/Objects/Scenario 15.4f078c.ttslua
@@ -64,6 +64,8 @@ buttonData = {
     [7] = { position = {0.62, 0.1, 0.89}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click to get Scenario Rewards' }
 }
 
+gridData = { scale =  2.59, x = -1.0, y = -0.1 }
+
 function setupAllDRooms()
     setupRoom(3)
 end

--- a/Objects/Scenario 16.052a4a.ttslua
+++ b/Objects/Scenario 16.052a4a.ttslua
@@ -27,3 +27,5 @@ overlayPositionsByRoom = {
     [1] = { position = {-1.094, 0.1, -0.93}, label = '', message = '', nextButtons = { 2 }, action = "initializeScenario", hint = 'Setup Scenario'},
     [2] = { position = {0.36, 0.1, 0.85}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
  }
+
+ gridData = { scale =  2.67, x = -1.0, y = -1.1 }

--- a/Objects/Scenario 17.d0a22a.ttslua
+++ b/Objects/Scenario 17.d0a22a.ttslua
@@ -76,6 +76,8 @@ buttonData = {
    [4] = { position = {2.05, 0.1, 0.7}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.67, x = -0.1, y = 0.1 }
+
 function fotoHP()
     local playerCount = saveState['playerCount']
     local scenarioLevel = saveState['scenarioLevel']

--- a/Objects/Scenario 18.8830a0.ttslua
+++ b/Objects/Scenario 18.8830a0.ttslua
@@ -89,3 +89,5 @@ buttonData = {
     [10] = { position = {0.33, 0.1, -0.64}, label = '', message = 'Please move golems to an appropriate position.', nextButtons = { 11 }, action = "setupRoom", hint = 'Setup monsters'},
     [11] = { position = {0.47, 0.1, 0.95}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
+
+gridData = { scale =  2.6, x = 1.1, y = 0.1 }

--- a/Objects/Scenario 19.5bb261.ttslua
+++ b/Objects/Scenario 19.5bb261.ttslua
@@ -161,3 +161,5 @@ buttonData = {
    [8] = {position = {0.46, 0.1, -0.76}, nextButtons = { 9 }, action = 'setupRoom', hint = 'Destroy nest', overrideButtonHeight = hexHeight},
    [9] = { position = {0.43, 0.1, 0.9}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
+
+gridData = { scale =  2.95, x = -0.7, y = 0.9 }

--- a/Objects/Scenario 2.b05eae.ttslua
+++ b/Objects/Scenario 2.b05eae.ttslua
@@ -64,3 +64,5 @@ buttonData = {
         message = 'Drop these Reward tokens on your character sheets to transfer rewards.',
         nextButtons = {}, action = "generateWinRewards", hint = "Click for Scenario Rewards" }
 }
+
+gridData = { scale =  2.73, x = 1.0, y = 0.7 }

--- a/Objects/Scenario 20.2541b2.ttslua
+++ b/Objects/Scenario 20.2541b2.ttslua
@@ -126,6 +126,8 @@ buttonData = {
     [14] = { position = {0.36, 0.1, 0.92 }, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.65, x = 1.1, y = 0.2 }
+
 function getRing()
     cleanupButton(7)
     local unavailableItemDeckGUID = Global.call('getItemDeck', 'unavailable')

--- a/Objects/Scenario 21.fe1e7b.ttslua
+++ b/Objects/Scenario 21.fe1e7b.ttslua
@@ -160,6 +160,8 @@ buttonData = {
    [16] = { position = {2.02, 0.1, 0.11}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.55, x = -0.2, y = 0.7 }
+
 function destroyTableA()
     cleanupButton(5)
     setupRoom(5)

--- a/Objects/Scenario 22.f9c420.ttslua
+++ b/Objects/Scenario 22.f9c420.ttslua
@@ -53,6 +53,8 @@ buttonData = {
     [2] = { position = {-1.29, 0.1, 0.85}, nextButtons = {}, action = "generateWinRewards", hint = "Click for Scenario Rewards" }
 }
 
+gridData = { scale =  2.82, x = -1.0, y = 0.8 }
+
 function healthTimesCharacterNum()
     local playerCount = saveState['playerCount']
     local scenarioLevel = saveState['scenarioLevel']

--- a/Objects/Scenario 23.167746.ttslua
+++ b/Objects/Scenario 23.167746.ttslua
@@ -69,6 +69,8 @@ buttonData = {
     [4] = { position = {0.36, 0.1, 0.9}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.65, x = -1.0, y = 0.0 }
+
 crowdMemberPositions = {
     [1] = { x = -5, z = 11.5 }, [2] = { x = -9, z = 9 }, [3] = { x = -9, z = -2.25 }, [4] = { x = -5, z = -4.6},
      [5] = { x = -5, z = 0.1 }, [6] = { x = -5, z = 7 }, [7] = { x = -9, z = 4.6 }, [8] = { x = -9, z = 2.3 },

--- a/Objects/Scenario 24.e4a395.ttslua
+++ b/Objects/Scenario 24.e4a395.ttslua
@@ -80,3 +80,5 @@ buttonData = {
     [3] = { position = {-0.01, 0.1, 0.52}, nextButtons = { 4 }, action = 'setupRoom', hint = 'Continue'},
     [4] = { position = {0.34, 0.1, 0.85}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
+
+gridData = { scale =  2.71, x = -0.9, y = -0.3 }

--- a/Objects/Scenario 25.8f1cd3.ttslua
+++ b/Objects/Scenario 25.8f1cd3.ttslua
@@ -171,3 +171,5 @@ buttonData = {
     -- win
     [18] = { position = {-0.9, 0.1, -0.45}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
+
+gridData = { scale =  2.51, x = 0.1, y = 1.1 }

--- a/Objects/Scenario 3.84ed7c.ttslua
+++ b/Objects/Scenario 3.84ed7c.ttslua
@@ -79,3 +79,5 @@ buttonData = {
     [3] = { position = {0.58, 0.1, -0.02}, nextButtons = { 4 }, action = "setupRoom", hint = 'Open door', overrideButtonHeight = hexHeight},
     [4] = { position = {0.4, 0.1, 0.75}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
+
+gridData = { scale =  2.71, x = -0.9, y = 0.36 }

--- a/Objects/Scenario 4.76f459.ttslua
+++ b/Objects/Scenario 4.76f459.ttslua
@@ -107,6 +107,8 @@ buttonData = {
     [8] = { position = {0.37, 0.1, 0.85}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.79, x = -1.0, y = 0.2 }
+
 function destroyStoneA()
     setupRoom(2)
     destroyStone()

--- a/Objects/Scenario 5.880612.ttslua
+++ b/Objects/Scenario 5.880612.ttslua
@@ -79,6 +79,8 @@ buttonData = {
    [4] = { position = {0, 0.1, -0.39}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.98, x = -0.5, y = -0.4 }
+
 function reduceBy4C()
     local playerCount = saveState['playerCount']
     local scenarioLevel = saveState['scenarioLevel']

--- a/Objects/Scenario 6.6168da.ttslua
+++ b/Objects/Scenario 6.6168da.ttslua
@@ -103,3 +103,5 @@ buttonData = {
     [9] = { position = {2.14, 0.1, -0.18}, nextButtons = {}, action = 'setupRoom', hint = 'Destroy Growth'},
     [10] = { position = {1.93, 0.1, 0.41}, nextButtons = {}, action = 'setupRoom', hint = 'Destroy Growth'},
 }
+
+gridData = { scale =  2.58, x = 0.6, y = -0.4 }

--- a/Objects/Scenario 7.948b2e.ttslua
+++ b/Objects/Scenario 7.948b2e.ttslua
@@ -103,6 +103,8 @@ buttonData = {
    [4] = { position = {0.38, 0.1, 0.74}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards'}
 }
 
+gridData = { scale =  2.58, x = 0.8, y = -0.7 }
+
 function reduceByCx2()
     local playerCount = saveState['playerCount']
     local scenarioLevel = saveState['scenarioLevel']

--- a/Objects/Scenario 8.9833ac.ttslua
+++ b/Objects/Scenario 8.9833ac.ttslua
@@ -78,6 +78,8 @@ buttonData = {
    [3] = { position = {1.7, 0.1, 0.22}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards'}
 }
 
+gridData = { scale =  2.57, x = 0.1, y = -0.6 }
+
 function reduceByCx2()
     local playerCount = saveState['playerCount']
     local scenarioLevel = saveState['scenarioLevel']

--- a/Objects/Scenario 9.b4031a.ttslua
+++ b/Objects/Scenario 9.b4031a.ttslua
@@ -97,6 +97,8 @@ buttonData = {
    [5] = { position = {0.88, 0.1, -0.88}, nextButtons = {}, action = 'generateWinRewards', hint = 'Click for Scenario Rewards' }
 }
 
+gridData = { scale =  2.76, x = -1.0, y = -0.5 }
+
 function reduceByCx2()
     local playerCount = saveState['playerCount']
     local scenarioLevel = saveState['scenarioLevel']

--- a/ScenarioSetup.ttslua
+++ b/ScenarioSetup.ttslua
@@ -16,6 +16,42 @@ function onLoad(save_state)
     initializeSetupButtons()
 end
 
+function onDrop(player_color)
+    -- Follow the dropped map until it lands.
+    Wait.frames(followLanding, 1)
+
+    -- Set appropriate options for the Grid
+    Grid.type = 2
+    Grid.snapping = 3
+
+    if gridData ~= nil then
+        Grid.sizeX = gridData.scale
+        Grid.sizeY = gridData.scale
+    end
+
+    -- Useful for debugging - show grid lines.
+    --Grid.show_lines = true -- for debugging
+    --self.grid_projection = true
+end
+
+function followLanding()
+    -- keep following the landing until the map is resting
+    if not self.resting then
+        Wait.frames(followLanding, 1)
+    end
+
+    local pos = self.getPosition()
+
+    -- There's some confusion here, as Grid refers to X and Y, but these
+    -- correspond to the X and Z dimensions of objects. Just note that the
+    -- mixing of y & z is intentional.
+    if gridData ~= nil then
+        Grid.offsetX = gridData.x + pos.x
+        Grid.offsetY = gridData.y + pos.z
+    end
+
+end
+
 function initializeScenario()
     local level = Global.call('getScenarioLevel')
     local playerCount = Global.call('getPlayerCount')


### PR DESCRIPTION
TTS provides a global Grid object for snapping objects to. This patch does not enable grid snapping on any objects, only adjusts the Grid's settings to match the most recently dropped map.

Every scenario has a table 'gridData' holding a scale/size and x/y offset. The 'y' offset matches the wording in the Grid Settings, but corresponds to the 'z' dimension from Object.getPosition().

ScenarioSetup gets an onDrop() function, and followLanding() gets called every frame until the dropped map is 'resting'.